### PR TITLE
feat: Improved IPv6 support for the API Server

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -98,11 +98,11 @@ async def main():
     
     api_config = uvicorn.Config(
         "app.api:api_app",
-        host="0.0.0.0",
+        host="",
         port=settings.api_port,
         log_config=None,
         proxy_headers=True,
-        forwarded_allow_ips="127.0.0.1"
+        forwarded_allow_ips=["127.0.0.1", "::1"]
     )
     api_server = uvicorn.Server(api_config)
     


### PR DESCRIPTION
- Changed 0.0.0.0 to an empty string, as described in [this discussion](https://github.com/Kludex/uvicorn/discussions/1529#discussioncomment-3061823).
- Added the localhost IPv6 equivalent (::1) to the allowed forwarded IPs.