### PR TITLE
feat(launch): pass the client's timezone through to the container TZ

### DIFF
--- a/browser_extension/options.js
+++ b/browser_extension/options.js
@@ -747,7 +747,8 @@ function initializeAppLaboratoryTab() {
 
       const launchPayload = {
         application_id: appToLaunch.id,
-        wayland_mode: launchWaylandCheckbox.checked
+        wayland_mode: launchWaylandCheckbox.checked,
+        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone
       };
       const { sealskinConfig } = await chrome.storage.local.get('sealskinConfig');
       const launchResponse = await secureFetch('/api/admin/launch/meta_customize', { method: 'POST', body: JSON.stringify(launchPayload) });

--- a/browser_extension/popup.js
+++ b/browser_extension/popup.js
@@ -753,6 +753,7 @@ async function handleLaunch() {
       application_id: selectedAppId,
       home_name: finalHomeName,
       language: languageSelect.value,
+      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
       selected_gpu: selectedGpuValue,
       launch_in_room_mode: collaborationMode,
       wayland_mode: waylandMode,

--- a/server/app/api.py
+++ b/server/app/api.py
@@ -1328,7 +1328,7 @@ async def ensure_container_for_session(session_id: str, target_app_id: str) -> d
         "PGID": str(settings.pgid),
         "CUSTOM_USER": session.get("custom_user", "abc"),
         "PASSWORD": session.get("password", "abc"),
-        "TZ": "Etc/UTC",
+        "TZ": session.get("timezone") or os.environ.get("TZ") or "Etc/UTC",
         "SELKIES_ALLOWED_ORIGINS": "*",
     }
     if session.get("wayland_mode", True):
@@ -1521,6 +1521,19 @@ async def stop_container_in_session(session_id: str, target_app_id: str):
         del session["container_registry"][target_app_id]
         await save_sessions_to_disk()
 
+_TZ_NAME_RE = re.compile(r"^[A-Za-z0-9_+-]+(/[A-Za-z0-9_+-]+){0,2}$")
+
+def _resolve_timezone(client_timezone: Optional[str]) -> str:
+    """Pick the container TZ: the client's zone when it looks like an
+    IANA name, otherwise the server's own TZ, otherwise the previous Etc/UTC."""
+    if (
+        client_timezone
+        and len(client_timezone) <= 64
+        and _TZ_NAME_RE.match(client_timezone)
+    ):
+        return client_timezone
+    return os.environ.get("TZ") or "Etc/UTC"
+
 async def _launch_common(
     application_id: str,
     username: str,
@@ -1535,6 +1548,7 @@ async def _launch_common(
     forced_rw_mount: Optional[str] = None,
     launch_in_room_mode: bool = False,
     wayland_mode: bool = True,
+    timezone: Optional[str] = None,
 ) -> dict:
     app_config = INSTALLED_APPS.get(application_id)
     if not app_config:
@@ -1564,7 +1578,7 @@ async def _launch_common(
         "PGID": str(settings.pgid),
         "CUSTOM_USER": custom_user,
         "PASSWORD": password,
-        "TZ": "Etc/UTC",
+        "TZ": _resolve_timezone(timezone),
         "SELKIES_ALLOWED_ORIGINS": "*",
     }
 
@@ -1889,6 +1903,7 @@ async def _launch_common(
             "password": password,
             "gpu_config": gpu_config,
             "wayland_mode": wayland_mode,
+            "timezone": _resolve_timezone(timezone),
             "container_registry": {
                 application_id: {
                     "instance_id": instance_details["instance_id"],
@@ -1952,6 +1967,7 @@ async def launch_simple(
             req.selected_gpu,
             launch_in_room_mode=req.launch_in_room_mode,
             wayland_mode=req.wayland_mode,
+            timezone=req.timezone,
         )
     except ValidationError as e:
         raise HTTPException(status_code=422, detail=f"Invalid request body: {e}")
@@ -1974,6 +1990,7 @@ async def launch_url(
             req.selected_gpu,
             launch_in_room_mode=req.launch_in_room_mode,
             wayland_mode=req.wayland_mode,
+            timezone=req.timezone,
         )
     except ValidationError as e:
         raise HTTPException(status_code=422, detail=f"Invalid request body: {e}")
@@ -2011,6 +2028,7 @@ async def launch_file(
             req.open_file_on_launch,
             launch_in_room_mode=req.launch_in_room_mode,
             wayland_mode=req.wayland_mode,
+            timezone=req.timezone,
         )
     except ValidationError as e:
         raise HTTPException(status_code=422, detail=f"Invalid request body: {e}")
@@ -2049,7 +2067,7 @@ async def launch_file_path(
         env_vars = {"SEALSKIN_FILE": container_file_path}
 
         return await _launch_common(
-            req.application_id, username, auth_user["effective_settings"], req.home_name, env_vars, req.language, req.selected_gpu, wayland_mode=req.wayland_mode,
+            req.application_id, username, auth_user["effective_settings"], req.home_name, env_vars, req.language, req.selected_gpu, wayland_mode=req.wayland_mode, timezone=req.timezone,
         )
     except ValidationError as e:
         raise HTTPException(status_code=422, detail=f"Invalid request body: {e}")
@@ -2388,6 +2406,7 @@ async def launch_meta_for_customization(
             selected_gpu=req.selected_gpu,
             forced_rw_mount=template_path,
             wayland_mode=req.wayland_mode,
+            timezone=req.timezone,
         )
     except ValidationError as e:
         raise HTTPException(status_code=422, detail=f"Invalid request body: {e}")

--- a/server/app/models.py
+++ b/server/app/models.py
@@ -22,6 +22,7 @@ class LaunchRequestSimple(BaseModel):
     application_id: str
     home_name: Optional[str] = None
     language: Optional[str] = None
+    timezone: Optional[str] = None
     selected_gpu: Optional[str] = None
     launch_in_room_mode: bool = False
     wayland_mode: bool = True
@@ -31,6 +32,7 @@ class LaunchRequestURL(BaseModel):
     application_id: str
     home_name: Optional[str] = None
     language: Optional[str] = None
+    timezone: Optional[str] = None
     selected_gpu: Optional[str] = None
     launch_in_room_mode: bool = False
     wayland_mode: bool = True
@@ -43,6 +45,7 @@ class LaunchRequestFile(BaseModel):
     open_file_on_launch: bool = True
     home_name: Optional[str] = None
     language: Optional[str] = None
+    timezone: Optional[str] = None
     selected_gpu: Optional[str] = None
     launch_in_room_mode: bool = False
     wayland_mode: bool = True
@@ -203,6 +206,7 @@ class CreateMetaAppRequest(BaseModel):
 class LaunchMetaCustomizeRequest(BaseModel):
     application_id: str
     language: Optional[str] = None
+    timezone: Optional[str] = None
     selected_gpu: Optional[str] = None
     wayland_mode: bool = True
 
@@ -324,6 +328,7 @@ class LaunchRequestFilePath(BaseModel):
     home_name: Optional[str] = None
     filename: str
     language: Optional[str] = None
+    timezone: Optional[str] = None
     selected_gpu: Optional[str] = None
     wayland_mode: bool = True
 


### PR DESCRIPTION
Fixes #8.

Every launched container had `TZ` pinned to `Etc/UTC`. Following the approach thelamer described in the issue, the launch payloads now carry the browser's own IANA zone name (`Intl.DateTimeFormat().resolvedOptions().timeZone`), as a sibling of the existing `language` field on the launch request models.

The server resolves it in `_resolve_timezone`: a well-formed client zone wins, otherwise the sealskin server's own `TZ`, otherwise the previous `Etc/UTC`. The resolved zone is stored in the session, so containers started later for the same session (`ensure_container_for_session`) get the same clock. Zone names are validated against the IANA name shape and capped at 64 characters before they reach a container environment; anything else falls back rather than erroring.

Touched: the five launch request models, all five `_launch_common` call sites (passed by keyword), the session dict, and the two extension payload builders (`popup.js`, `options.js`). Old sessions persisted from before this change fall back to the server TZ.
